### PR TITLE
Patch Generate Ensemble Action Failure

### DIFF
--- a/R/generate_hub_ensemble.R
+++ b/R/generate_hub_ensemble.R
@@ -111,8 +111,7 @@ generate_hub_ensemble <- function(
 
   weekly_forecasts <- hubData::connect_hub(base_hub_path) |>
     dplyr::filter(
-      .data$reference_date == !!reference_date,
-      !stringr::str_detect(.data$model_id, !!hub_name)
+      .data$reference_date == !!reference_date
     ) |>
     hubData::collect_hub()
 


### PR DESCRIPTION
This PR:

* [x] Patches the following error, which occurred in `rsv-forecast-hub` here: <https://github.com/CDCgov/rsv-forecast-hub/actions/runs/18009501647/job/51237984121>

<img width="792" height="413" alt="Screenshot 2025-09-25 at 15 04 13" src="https://github.com/user-attachments/assets/c62aa3bf-2193-4df1-8bb2-21dea6508da7" />

