### PR TITLE
Fix R-Action Check-Package Failure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,8 @@ Imports:
     jsonlite,
     lubridate,
     purrr,
+    RcppTOML,
+    readr,
     stringr,
     tidyr,
     tidyselect,


### PR DESCRIPTION
This PR:

* [x] Updates the `DESCRIPTION` file with the packages `RcppTOML`, `readr`, and `glue` to avoid `r-lib` failures with `check-r-package` (e.g. <https://github.com/CDCgov/hubhelpr/actions/runs/19471845892/job/55721111394>).