### PR TITLE
Update Pre-Commit Config And Lintr

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
-linters: linters_with_defaults(object_usage_linter = NULL, return_linter = NULL, line_length_linter = NULL)
+linters: linters_with_defaults(object_usage_linter = NULL, return_linter = NULL, line_length_linter = NULL, indentation_linter = NULL, object_length_linter = NULL)
 encoding: "UTF-8"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,21 +30,7 @@ repos:
     rev: v0.4.3.9017
     hooks:
     -   id: lintr
-#####
-# Java
-- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.15.0
-  hooks:
-  - id: pretty-format-java
-    args: [--aosp,--autofix]
-#####
-# Julia
-# Due to lack of first-class Julia support, this needs Julia local install
-#   and JuliaFormatter.jl installed in the library
-# - repo: https://github.com/domluna/JuliaFormatter.jl
-#   rev: v1.0.39
-#   hooks:
-#   - id: julia-formatter
+        files: \.R$|\.Rmd$
 #####
 # Secrets
 -   repo: https://github.com/Yelp/detect-secrets


### PR DESCRIPTION
This PR:

* [x] Updates exclusions in `.lintr` so preferred function names can be used. 
* [x] Isolates `lintr` hook usage to R and Rmd.