### PR TITLE
Update US Location Recoding From Forecasttools To Use HRD Over Abbreviations

### DIFF
--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -64,10 +64,9 @@ update_hub_target_data <- function(
     dplyr::mutate(
       date = lubridate::as_date(.data$weekendingdate),
       observation = as.numeric(.data[[nhsn_col_name]]),
-      jurisdiction = stringr::str_replace(.data$jurisdiction, "USA", "US"),
       location = forecasttools::us_location_recode(
         .data$jurisdiction,
-        "abbr",
+        "hrd",
         "code"
       ),
       as_of = !!as_of,

--- a/R/write_webtext.R
+++ b/R/write_webtext.R
@@ -35,14 +35,7 @@ check_hospital_reporting_latency <- function(
   included_jurisdictions <- forecasttools::us_location_recode(
     included_locations,
     "code",
-    "abbr"
-  )
-
-  # convert "US" to "USA" for API compatibility
-  included_jurisdictions <- dplyr::case_match(
-    included_jurisdictions,
-    "US" ~ "USA",
-    .default = included_jurisdictions
+    "hrd"
   )
 
   percent_hosp_reporting_below80 <- forecasttools::pull_data_cdc_gov_dataset(
@@ -57,19 +50,14 @@ check_hospital_reporting_latency <- function(
       report_above_80_lgl = as.logical(
         as.numeric(.data[[reporting_column]])
       ),
-      jurisdiction = dplyr::case_match(
-        .data$jurisdiction,
-        "USA" ~ "US",
-        .default = .data$jurisdiction
-      ),
       location = forecasttools::us_location_recode(
         .data$jurisdiction,
-        "abbr",
+        "hrd",
         "code"
       ),
       location_name = forecasttools::us_location_recode(
         .data$jurisdiction,
-        "abbr",
+        "hrd",
         "name"
       )
     )


### PR DESCRIPTION
This PR updates the argument from `abbr` to `hrd` across this codebase in the `us_location_recode` method from `forecasttools`. The new argument `hrd` encodes United States as "USA" making it convenient to use with data pulled from data.cdc.gov API 