### PR TITLE
Add Target To The List Of Columns Included In The Table Of Model Forecasts 

### DIFF
--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -122,7 +122,7 @@ update_hub_target_data <- function(
       dplyr::select(
         "week_end",
         "geography",
-        dplyr::all_of(nssp_col_name)
+        tidyselect::all_of(nssp_col_name)
       )
   } else {
     raw_nssp_data <- forecasttools::pull_data_cdc_gov_dataset(
@@ -145,7 +145,7 @@ update_hub_target_data <- function(
       target = glue::glue("wk inc {disease} prop ed visits")
     ) |>
     dplyr::filter(.data$location %in% !!included_locations) |>
-    dplyr::select(dplyr::all_of(hubverse_ts_req_cols)) |>
+    dplyr::select(tidyselect::all_of(hubverse_ts_req_cols)) |>
     dplyr::arrange(.data$date, .data$location)
 
   assert_data_up_to_date(

--- a/R/write_ref_date_summary.R
+++ b/R/write_ref_date_summary.R
@@ -26,9 +26,10 @@
 #' include. If NULL (default), includes all models.
 #' @param population_data data frame with columns
 #' "location" and "population".
-#' @param column_selection Columns to include in the output table.
-#' Uses [tidy selection](https://dplyr.tidyverse.org/articles/programming.html).
-#' Default: [tidyselect::everything()].
+#' @param column_selection Character vector of column names to
+#' include in the output table. Supports column renaming via
+#' named elements (e.g., `c(new_name = "old_name")`).
+#' If NULL (default), includes all columns.
 #'
 #' @return invisibly returns the file path where data was
 #' written
@@ -46,7 +47,7 @@ write_ref_date_summary <- function(
   targets = NULL,
   model_ids = NULL,
   population_data,
-  column_selection = tidyselect::everything()
+  column_selection = NULL
 ) {
   reference_date <- lubridate::as_date(reference_date)
 
@@ -61,8 +62,10 @@ write_ref_date_summary <- function(
     model_ids = model_ids
   )
 
-  summary_data <- summary_data |>
-    dplyr::select({{ column_selection }})
+  if (!is.null(column_selection)) {
+    summary_data <- summary_data |>
+      dplyr::select(tidyselect::all_of(column_selection))
+  }
 
   output_folder_path <- fs::path(
     hub_reports_path,
@@ -130,7 +133,7 @@ write_ref_date_summary_ens <- function(
   hub_name <- get_hub_name(disease)
   ensemble_model_name <- glue::glue("{hub_name}-ensemble")
 
-  ensemble_columns <- tidyselect::all_of(c(
+  ensemble_columns <- c(
     "location_name",
     "horizon",
     "quantile_0.025_per100k",
@@ -153,7 +156,7 @@ write_ref_date_summary_ens <- function(
     "forecast_due_date_formatted",
     "reference_date_formatted",
     model = "model_id"
-  ))
+  )
 
   write_ref_date_summary(
     reference_date = reference_date,
@@ -210,7 +213,7 @@ write_ref_date_summary_all <- function(
   output_format = "csv",
   targets = NULL
 ) {
-  all_models_columns <- tidyselect::all_of(c(
+  all_models_columns <- c(
     "location_name",
     "abbreviation",
     "horizon",
@@ -231,7 +234,7 @@ write_ref_date_summary_all <- function(
     forecast_team = "team_name",
     "forecast_due_date",
     model_full_name = "model_name"
-  ))
+  )
 
   write_ref_date_summary(
     reference_date = reference_date,

--- a/man/write_ref_date_summary.Rd
+++ b/man/write_ref_date_summary.Rd
@@ -16,7 +16,7 @@ write_ref_date_summary(
   targets = NULL,
   model_ids = NULL,
   population_data,
-  column_selection = tidyselect::everything()
+  column_selection = NULL
 )
 }
 \arguments{
@@ -54,9 +54,10 @@ include. If NULL (default), includes all models.}
 \item{population_data}{data frame with columns
 "location" and "population".}
 
-\item{column_selection}{Columns to include in the output table.
-Uses \href{https://dplyr.tidyverse.org/articles/programming.html}{tidy selection}.
-Default: \code{\link[tidyselect:everything]{tidyselect::everything()}}.}
+\item{column_selection}{Character vector of column names to
+include in the output table. Supports column renaming via
+named elements (e.g., \code{c(new_name = "old_name")}).
+If NULL (default), includes all columns.}
 }
 \value{
 invisibly returns the file path where data was


### PR DESCRIPTION
This PR adds `target` as a variable in `all_models_columns`, which is the list of columns to pass to `write_ref_date_summary()`, which generates and writes forecast data for all models.