### PR TITLE
Add Target Data Type Column To Function For Writing Visualization Data

### DIFF
--- a/R/write_viz_target_data.R
+++ b/R/write_viz_target_data.R
@@ -49,6 +49,7 @@ write_viz_target_data <- function(
         "code",
         "name"
       ),
+      target_data_type = get_target_data_type(.data$target),
       observation = dplyr::if_else(
         grepl("ed visits", .data$target),
         round(.data$observation, 4),
@@ -60,6 +61,7 @@ write_viz_target_data <- function(
       "location",
       "location_name",
       "target",
+      "target_data_type",
       value = "observation"
     )
 


### PR DESCRIPTION
This PR adds the `target_data_type` column to the visualization target data produced by `write_viz_target_data`. The `target_data_type` column was added and explained in #117 .