### PR TITLE
Add Dependabot File

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "10:00"
+      timezone: "America/Denver"
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Automation"


### PR DESCRIPTION
This PR adds a `dependabot.yaml` file for maintainence of action versioning and security updates. An STF standard is using `dependabot.yaml` files. The `dependabot.yaml` file employed here is identical to the one in `covid19-forecast-hub` and `rsv-forecast-hub`.