### PR TITLE
Add Composite Action For Generating Baseline Hub Forecasts

### DIFF
--- a/actions/generate-baseline/action.yaml
+++ b/actions/generate-baseline/action.yaml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: "."
   reference_date:
-    description: "Reference date for the forecast (YYYY-MM-DD, must be a Saturday). Defaults to the ceiling of the current MMWR epiweek."
+    description: "Reference date for the forecast (YYYY-MM-DD, must be a Saturday). Defaults to the last day of the current MMWR epiweek."
     required: false
     default: "latest"
 


### PR DESCRIPTION
This PR adds an action called `generate-baseline` which can be used by STF hubs for generating baseline forecasts. 

The following decisions are involved in this PR:

* R setup is the caller's responsibility.
* Reference date defaults internally but is overridable.
* Hub name is derived, not passed as input
* The action owns the full commit-and-PR process.
* The GitHub token is an input ad is not assumed.
* Unified reference date computation (`forecasttools::ceiling_mmwr_epiweek`).

Decisions in this PR are relevant to completing #87 .