### PR TITLE
Fix Empty Reference Date Handling For Baseline And Ensemble Forecast Actions

### DIFF
--- a/actions/generate-baseline/action.yaml
+++ b/actions/generate-baseline/action.yaml
@@ -26,7 +26,7 @@ runs:
       run: |
         today <- lubridate::today()
         input_date <- "${{ inputs.reference_date }}"
-        if (input_date == "latest") {
+        if (input_date == "latest" || nchar(input_date) == 0) {
           ref_date <- forecasttools::ceiling_mmwr_epiweek(today)
         } else {
           ref_date <- as.Date(input_date)

--- a/actions/generate-ensemble/action.yaml
+++ b/actions/generate-ensemble/action.yaml
@@ -30,7 +30,7 @@ runs:
       run: |
         today <- lubridate::today()
         input_date <- "${{ inputs.reference_date }}"
-        if (input_date == "latest") {
+        if (input_date == "latest" || nchar(input_date) == 0) {
           ref_date <- forecasttools::ceiling_mmwr_epiweek(today)
         } else {
           ref_date <- as.Date(input_date)


### PR DESCRIPTION
This PR fixes empty reference date handling, e.g. <https://github.com/CDCgov/covid19-forecast-hub/actions/runs/21455013977/job/61793484842>.