### PR TITLE
Fix Settings For Reference Date For Baseline And Ensemble Actions

### DIFF
--- a/actions/generate-baseline/action.yaml
+++ b/actions/generate-baseline/action.yaml
@@ -15,7 +15,6 @@ inputs:
   reference_date:
     description: "Reference date for the forecast (YYYY-MM-DD, must be a Saturday). Defaults to the last day of the current MMWR epiweek."
     required: true
-    default: "latest"
 
 runs:
   using: "composite"

--- a/actions/generate-ensemble/action.yaml
+++ b/actions/generate-ensemble/action.yaml
@@ -15,7 +15,6 @@ inputs:
   reference_date:
     description: "Reference date for the forecast (YYYY-MM-DD, must be a Saturday). Defaults to the last day of the current MMWR epiweek."
     required: true
-    default: "latest"
   ensemble_targets:
     description: "JSON/YAML array of forecast targets for which to generate ensembles (e.g., '[\"hosp\", \"prop ed visits\"]')."
     required: false


### PR DESCRIPTION
This PR fixes an error in the `covid19-forecast-hub` workflow for baseline and ensemble forecast generation that arose from `reference_date` in `generate-baseline/action.yaml` and `generate-ensemble/action.yaml` having `required` set to `false` instead of `true`.