### PR TITLE
Address CI error on Windows

### DIFF
--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -305,17 +305,18 @@ update_hub_target_data <- function(
   new_data <- dplyr::bind_rows(nhsn_data, nssp_data)
 
   if (fs::file_exists(output_file)) {
-    existing_data <- forecasttools::read_tabular_file(output_file)
+    existing_data <- forecasttools::read_tabular(output_file)
   } else {
     existing_data <- NULL
   }
 
-  merge_target_data(
+  new_data <- merge_target_data(
     existing_data,
     new_data,
     overwrite_existing = overwrite_existing
-  ) |>
-    forecasttools::write_tabular_file(output_file)
+  )
+
+  forecasttools::write_tabular(new_data, output_file)
 
   return(invisible())
 }

--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -310,13 +310,13 @@ update_hub_target_data <- function(
     existing_data <- NULL
   }
 
-  new_data <- merge_target_data(
+  merged_data <- merge_target_data(
     existing_data,
     new_data,
     overwrite_existing = overwrite_existing
   )
 
-  forecasttools::write_tabular(new_data, output_file)
+  forecasttools::write_tabular(merged_data, output_file)
 
   return(invisible())
 }

--- a/tests/testthat/test_update_hub_target_data.R
+++ b/tests/testthat/test_update_hub_target_data.R
@@ -83,7 +83,7 @@ purrr::walk(c("covid", "rsv"), function(disease) {
           as_of = lubridate::as_date("2025-08-18")
         )
 
-        # second run :with same data errors by default
+        # second run with same data errors by default
         expect_error(
           hubhelpr::update_hub_target_data(
             base_hub_path = base_hub_path,


### PR DESCRIPTION
This PR resolves an R CMD check failure on Windows that was not present on macOS or Linux.

It also updates the names of some forecasttools functions to the latest versions and fixes a typo.

## Details
[Example error](https://github.com/CDCgov/hubhelpr/actions/runs/22490524661/job/65151223907?pr=151)
```R
── Error ('test_update_hub_target_data.R:98:9'): update_hub_target_data errors on duplicate run for covid ──
Error: Error: IOError: Failed to open local file 
'C:/Users/runneradmin/AppData/Local/Temp/RtmpQ7s9DZ/working_dir/Rtmp8qgU5V/base_hub_dup_covid_20f427bc3270/target-data/time-series.parquet'. 
Detail: [Windows error 1224] The requested operation cannot be performed on a file with a user-mapped section open.
```

My hypothesis based on the error message is that on windows the connection to `time-series.parquet` gets opened _before_ `merge_target_data` errors and then does not get closed. This then causes the subsequent attempt to interact with it to error. If so, getting rid of the pipechain may resolve.

Update: it appears to.