### PR TITLE
Add Argument For Overwriting Forecast Summary And Allow Exclusions For Specific Targets

### DIFF
--- a/R/summarize_ref_date_forecasts.R
+++ b/R/summarize_ref_date_forecasts.R
@@ -52,7 +52,9 @@ build_exclusion_df <- function(excluded_locations) {
     tidyr::unnest(cols = "location") |>
     dplyr::mutate(
       location = forecasttools::us_location_recode(
-        .data$location, "abbr", "hub"
+        .data$location,
+        "abbr",
+        "hub"
       )
     )
 }
@@ -107,7 +109,9 @@ summarize_ref_date_forecasts <- function(
 
   global_excluded_codes <- if ("all" %in% names(excluded_locations)) {
     forecasttools::us_location_recode(
-      excluded_locations[["all"]], "abbr", "hub"
+      excluded_locations[["all"]],
+      "abbr",
+      "hub"
     )
   } else {
     character(0)

--- a/R/summarize_ref_date_forecasts.R
+++ b/R/summarize_ref_date_forecasts.R
@@ -15,8 +15,14 @@
 #' and "population". Adds population-based calculations.
 #' @param horizons_to_include integer vector, horizons to
 #' include in the output. Default: c(0, 1, 2).
-#' @param excluded_locations character vector of location
-#' codes to exclude from the output. Default: character(0).
+#' @param excluded_locations character vector of US state
+#' abbreviations to exclude from the output across all
+#' targets. Converted to hub codes internally. Default:
+#' character(0).
+#' @param excluded_locations_by_target named list mapping
+#' target names to character vectors of US state
+#' abbreviations to exclude for that target only. Default:
+#' list().
 #' @param targets character vector, target name(s) to filter
 #' forecasts. If NULL (default), does not filter by target.
 #' @param model_ids character vector of model IDs to include.
@@ -32,10 +38,18 @@ summarize_ref_date_forecasts <- function(
   population_data,
   horizons_to_include = c(0, 1, 2),
   excluded_locations = character(0),
+  excluded_locations_by_target = list(),
   targets = NULL,
   model_ids = NULL
 ) {
   reference_date <- lubridate::as_date(reference_date)
+
+  # abbreviations to hub codes
+  excluded_location_codes <- if (length(excluded_locations) > 0) {
+    forecasttools::us_location_recode(excluded_locations, "abbr", "hub")
+  } else {
+    character(0)
+  }
 
   model_metadata <- hubData::load_model_metadata(
     base_hub_path,
@@ -47,7 +61,7 @@ summarize_ref_date_forecasts <- function(
   current_forecasts <- hub_content |>
     dplyr::filter(
       .data$reference_date == !!reference_date,
-      !(.data$location %in% !!excluded_locations),
+      !(.data$location %in% !!excluded_location_codes),
       .data$horizon %in% !!horizons_to_include
     ) |>
     hubData::collect_hub() |>
@@ -55,6 +69,17 @@ summarize_ref_date_forecasts <- function(
       forecasttools::nullable_comparison(.data$target, "%in%", !!targets),
       forecasttools::nullable_comparison(.data$model_id, "%in%", !!model_ids)
     )
+
+  # target-specific location exclusions
+  for (tgt in names(excluded_locations_by_target)) {
+    excluded_codes <- forecasttools::us_location_recode(
+      excluded_locations_by_target[[tgt]],
+      "abbr",
+      "hub"
+    )
+    current_forecasts <- current_forecasts |>
+      dplyr::filter(!(.data$target == tgt & .data$location %in% excluded_codes))
+  }
 
   if (nrow(current_forecasts) == 0) {
     model_filter_msg <- if (!is.null(model_ids)) {

--- a/R/summarize_ref_date_forecasts.R
+++ b/R/summarize_ref_date_forecasts.R
@@ -27,28 +27,37 @@ normalize_excluded_locations <- function(excluded_locations) {
 #' Build a target-location exclusion data frame.
 #'
 #' Constructs a tibble of target/location pairs to
-#' exclude, from target-specific entries in the
-#' normalized exclusion list (entries other than "all").
-#' The "all" key is handled separately(as pre-filter).
+#' exclude. Entries keyed by "all" are expanded into
+#' one row per available target. Errors if any named
+#' targets in the exclusion list are not in
+#' `available_targets`.
 #'
 #' @param excluded_locations Named list as returned by
 #' `normalize_excluded_locations()`.
+#' @param available_targets character vector of valid
+#' target names.
 #'
 #' @return A tibble with columns "target" and "location"
 #' (hub codes).
 #' @noRd
-build_exclusion_df <- function(excluded_locations) {
-  target_specific <- excluded_locations[
-    names(excluded_locations) != "all"
-  ]
-  if (length(target_specific) == 0) {
-    return(tibble::tibble(target = character(0), location = character(0)))
+build_exclusion_df <- function(excluded_locations, available_targets) {
+  named_targets <- setdiff(names(excluded_locations), "all")
+  invalid_targets <- setdiff(named_targets, available_targets)
+  if (length(invalid_targets) > 0) {
+    cli::cli_abort(
+      "{.arg excluded_locations} contains unknown target{?s}: {.val {invalid_targets}}."
+    )
   }
-  tibble::enframe(
-    target_specific,
-    name = "target",
-    value = "location"
-  ) |>
+
+  global_locs <- excluded_locations[["all"]] %||% character(0)
+  per_target <- excluded_locations[named_targets]
+
+  merged <- lapply(
+    stats::setNames(available_targets, available_targets),
+    \(tgt) unique(c(global_locs, per_target[[tgt]] %||% character(0)))
+  )
+
+  tibble::enframe(merged, name = "target", value = "location") |>
     tidyr::unnest(cols = "location") |>
     dplyr::mutate(
       location = forecasttools::us_location_recode(
@@ -103,19 +112,7 @@ summarize_ref_date_forecasts <- function(
   model_ids = NULL
 ) {
   reference_date <- lubridate::as_date(reference_date)
-
   excluded_locations <- normalize_excluded_locations(excluded_locations)
-  exclusion_df <- build_exclusion_df(excluded_locations)
-
-  global_excluded_codes <- if ("all" %in% names(excluded_locations)) {
-    forecasttools::us_location_recode(
-      excluded_locations[["all"]],
-      "abbr",
-      "hub"
-    )
-  } else {
-    character(0)
-  }
 
   model_metadata <- hubData::load_model_metadata(
     base_hub_path,
@@ -127,7 +124,6 @@ summarize_ref_date_forecasts <- function(
   current_forecasts <- hub_content |>
     dplyr::filter(
       .data$reference_date == !!reference_date,
-      !(.data$location %in% !!global_excluded_codes),
       .data$horizon %in% !!horizons_to_include
     ) |>
     hubData::collect_hub() |>
@@ -135,6 +131,9 @@ summarize_ref_date_forecasts <- function(
       forecasttools::nullable_comparison(.data$target, "%in%", !!targets),
       forecasttools::nullable_comparison(.data$model_id, "%in%", !!model_ids)
     )
+
+  available_targets <- unique(current_forecasts$target)
+  exclusion_df <- build_exclusion_df(excluded_locations, available_targets)
 
   if (nrow(exclusion_df) > 0) {
     current_forecasts <- current_forecasts |>

--- a/R/summarize_ref_date_forecasts.R
+++ b/R/summarize_ref_date_forecasts.R
@@ -49,12 +49,9 @@ build_exclusion_df <- function(excluded_locations, available_targets) {
     )
   }
 
-  global_locs <- excluded_locations[["all"]] %||% character(0)
-  per_target <- excluded_locations[named_targets]
-
-  merged <- lapply(
-    stats::setNames(available_targets, available_targets),
-    \(tgt) unique(c(global_locs, per_target[[tgt]] %||% character(0)))
+  merged <- purrr::map(
+    purrr::set_names(available_targets),
+    \(tgt) unique(c(excluded_locations[["all"]], excluded_locations[[tgt]]))
   )
 
   tibble::enframe(merged, name = "target", value = "location") |>

--- a/R/summarize_ref_date_forecasts.R
+++ b/R/summarize_ref_date_forecasts.R
@@ -1,3 +1,63 @@
+#' Normalize excluded locations to a named list.
+#'
+#' Converts a character vector or named list of excluded
+#' locations into a consistent named list format.
+#'
+#' @param excluded_locations NULL, character vector, or
+#' named list of character vector.
+#'
+#' @return Named list of character vectors.
+#' @noRd
+normalize_excluded_locations <- function(excluded_locations) {
+  if (is.null(excluded_locations)) {
+    return(list())
+  }
+  if (is.character(excluded_locations)) {
+    return(list("all" = excluded_locations))
+  }
+  if (is.list(excluded_locations)) {
+    return(excluded_locations)
+  }
+  cli::cli_abort(
+    "{.arg excluded_locations} must be NULL, a character vector, or a named list."
+  )
+}
+
+
+#' Build a target-location exclusion data frame.
+#'
+#' Constructs a tibble of target/location pairs to
+#' exclude, from target-specific entries in the
+#' normalized exclusion list (entries other than "all").
+#' The "all" key is handled separately(as pre-filter).
+#'
+#' @param excluded_locations Named list as returned by
+#' `normalize_excluded_locations()`.
+#'
+#' @return A tibble with columns "target" and "location"
+#' (hub codes).
+#' @noRd
+build_exclusion_df <- function(excluded_locations) {
+  target_specific <- excluded_locations[
+    names(excluded_locations) != "all"
+  ]
+  if (length(target_specific) == 0) {
+    return(tibble::tibble(target = character(0), location = character(0)))
+  }
+  tibble::enframe(
+    target_specific,
+    name = "target",
+    value = "location"
+  ) |>
+    tidyr::unnest(cols = "location") |>
+    dplyr::mutate(
+      location = forecasttools::us_location_recode(
+        .data$location, "abbr", "hub"
+      )
+    )
+}
+
+
 #' Summarize forecast hub data for a specific reference date.
 #'
 #' This function generates a tibble of forecast data
@@ -15,14 +75,13 @@
 #' and "population". Adds population-based calculations.
 #' @param horizons_to_include integer vector, horizons to
 #' include in the output. Default: c(0, 1, 2).
-#' @param excluded_locations character vector of US state
-#' abbreviations to exclude from the output across all
-#' targets. Converted to hub codes internally. Default:
-#' character(0).
-#' @param excluded_locations_by_target named list mapping
-#' target names to character vectors of US state
-#' abbreviations to exclude for that target only. Default:
-#' list().
+#' @param excluded_locations character vector or named list
+#' specifying US state abbreviations to exclude. If a
+#' character vector, locations are excluded across all
+#' targets. If a named list, names should be target names
+#' (or "all" for global exclusions) mapping to character
+#' vectors of abbreviations. Converted to hub codes
+#' internally. Default: NULL.
 #' @param targets character vector, target name(s) to filter
 #' forecasts. If NULL (default), does not filter by target.
 #' @param model_ids character vector of model IDs to include.
@@ -37,16 +96,19 @@ summarize_ref_date_forecasts <- function(
   disease,
   population_data,
   horizons_to_include = c(0, 1, 2),
-  excluded_locations = character(0),
-  excluded_locations_by_target = list(),
+  excluded_locations = NULL,
   targets = NULL,
   model_ids = NULL
 ) {
   reference_date <- lubridate::as_date(reference_date)
 
-  # abbreviations to hub codes
-  excluded_location_codes <- if (length(excluded_locations) > 0) {
-    forecasttools::us_location_recode(excluded_locations, "abbr", "hub")
+  excluded_locations <- normalize_excluded_locations(excluded_locations)
+  exclusion_df <- build_exclusion_df(excluded_locations)
+
+  global_excluded_codes <- if ("all" %in% names(excluded_locations)) {
+    forecasttools::us_location_recode(
+      excluded_locations[["all"]], "abbr", "hub"
+    )
   } else {
     character(0)
   }
@@ -61,7 +123,7 @@ summarize_ref_date_forecasts <- function(
   current_forecasts <- hub_content |>
     dplyr::filter(
       .data$reference_date == !!reference_date,
-      !(.data$location %in% !!excluded_location_codes),
+      !(.data$location %in% !!global_excluded_codes),
       .data$horizon %in% !!horizons_to_include
     ) |>
     hubData::collect_hub() |>
@@ -70,15 +132,9 @@ summarize_ref_date_forecasts <- function(
       forecasttools::nullable_comparison(.data$model_id, "%in%", !!model_ids)
     )
 
-  # target-specific location exclusions
-  for (tgt in names(excluded_locations_by_target)) {
-    excluded_codes <- forecasttools::us_location_recode(
-      excluded_locations_by_target[[tgt]],
-      "abbr",
-      "hub"
-    )
+  if (nrow(exclusion_df) > 0) {
     current_forecasts <- current_forecasts |>
-      dplyr::filter(!(.data$target == tgt & .data$location %in% excluded_codes))
+      dplyr::anti_join(exclusion_df, by = c("target", "location"))
   }
 
   if (nrow(current_forecasts) == 0) {

--- a/R/summarize_ref_date_forecasts.R
+++ b/R/summarize_ref_date_forecasts.R
@@ -135,10 +135,8 @@ summarize_ref_date_forecasts <- function(
   available_targets <- unique(current_forecasts$target)
   exclusion_df <- build_exclusion_df(excluded_locations, available_targets)
 
-  if (nrow(exclusion_df) > 0) {
-    current_forecasts <- current_forecasts |>
-      dplyr::anti_join(exclusion_df, by = c("target", "location"))
-  }
+  current_forecasts <- current_forecasts |>
+    dplyr::anti_join(exclusion_df, by = c("target", "location"))
 
   if (nrow(current_forecasts) == 0) {
     model_filter_msg <- if (!is.null(model_ids)) {

--- a/R/write_ref_date_summary.R
+++ b/R/write_ref_date_summary.R
@@ -15,8 +15,13 @@
 #' filename (e.g., "map_data", "forecasts_data").
 #' @param horizons_to_include integer vector, horizons to
 #' include in the output. Default: c(0, 1, 2).
-#' @param excluded_locations character vector of location
-#' codes to exclude from the output. Default: character(0).
+#' @param excluded_locations character vector of US state
+#' abbreviations to exclude from the output across all
+#' targets. Default: character(0).
+#' @param excluded_locations_by_target named list mapping
+#' target names to character vectors of US state
+#' abbreviations to exclude for that target only.
+#' Default: list().
 #' @param output_format character, output file format. One
 #' of "csv", "tsv", or "parquet". Default: "csv".
 #' @param targets character vector, target name(s) to
@@ -29,6 +34,8 @@
 #' @param column_selection Columns to include in the output
 #' table. Accepts tidyselect expressions. Default:
 #' [tidyselect::everything()].
+#' @param overwrite_existing logical. If TRUE, overwrite
+#' existing files. Default: FALSE.
 #'
 #' @return invisibly returns the file path where data was
 #' written
@@ -42,11 +49,13 @@ write_ref_date_summary <- function(
   file_suffix,
   horizons_to_include = c(0, 1, 2),
   excluded_locations = character(0),
+  excluded_locations_by_target = list(),
   output_format = "csv",
   targets = NULL,
   model_ids = NULL,
   population_data,
-  column_selection = tidyselect::everything()
+  column_selection = tidyselect::everything(),
+  overwrite_existing = FALSE
 ) {
   reference_date <- lubridate::as_date(reference_date)
 
@@ -57,6 +66,7 @@ write_ref_date_summary <- function(
     population_data = population_data,
     horizons_to_include = horizons_to_include,
     excluded_locations = excluded_locations,
+    excluded_locations_by_target = excluded_locations_by_target,
     targets = targets,
     model_ids = model_ids
   )
@@ -79,12 +89,17 @@ write_ref_date_summary <- function(
 
   fs::dir_create(output_folder_path)
 
-  if (!fs::file_exists(output_filepath)) {
-    forecasttools::write_tabular(summary_data, output_filepath)
-    cli::cli_inform("File saved as: {output_filepath}.")
-  } else {
-    cli::cli_abort("File already exists: {output_filepath}.")
+  if (fs::file_exists(output_filepath) && !overwrite_existing) {
+    cli::cli_abort(
+      c(
+        "File already exists: {output_filepath}.",
+        "i" = "Use {.arg overwrite_existing = TRUE} to overwrite."
+      )
+    )
   }
+
+  forecasttools::write_tabular(summary_data, output_filepath)
+  cli::cli_inform("File saved as: {output_filepath}.")
 
   invisible(output_filepath)
 }
@@ -105,13 +120,20 @@ write_ref_date_summary <- function(
 #' include in the output. Default: c(0, 1, 2).
 #' @param population_data data frame with columns
 #' "location" and "population". Default: population_data.
-#' @param excluded_locations character vector of location
-#' codes to exclude from the output. Default: character(0).
+#' @param excluded_locations character vector of US state
+#' abbreviations to exclude from the output across all
+#' targets. Default: character(0).
+#' @param excluded_locations_by_target named list mapping
+#' target names to character vectors of US state
+#' abbreviations to exclude for that target only.
+#' Default: list().
 #' @param output_format character, output file format. One
 #' of "csv", "tsv", or "parquet". Default: "csv".
 #' @param targets character vector, target name(s) to
 #' filter forecasts. If NULL (default), does not filter by
 #' target.
+#' @param overwrite_existing logical. If TRUE, overwrite
+#' existing files. Default: FALSE.
 #'
 #' @return invisibly returns the file path where data was
 #' written
@@ -125,8 +147,10 @@ write_ref_date_summary_ens <- function(
   horizons_to_include = c(0, 1, 2),
   population_data = hubhelpr::population_data,
   excluded_locations = character(0),
+  excluded_locations_by_target = list(),
   output_format = "csv",
-  targets = NULL
+  targets = NULL,
+  overwrite_existing = FALSE
 ) {
   hub_name <- get_hub_name(disease)
   ensemble_model_name <- glue::glue("{hub_name}-ensemble")
@@ -165,11 +189,13 @@ write_ref_date_summary_ens <- function(
     file_suffix = "map_data",
     horizons_to_include = horizons_to_include,
     excluded_locations = excluded_locations,
+    excluded_locations_by_target = excluded_locations_by_target,
     output_format = output_format,
     targets = targets,
     model_ids = ensemble_model_name,
     population_data = population_data,
-    column_selection = ensemble_columns
+    column_selection = ensemble_columns,
+    overwrite_existing = overwrite_existing
   )
 }
 
@@ -189,13 +215,20 @@ write_ref_date_summary_ens <- function(
 #' include in the output. Default: c(0, 1, 2).
 #' @param population_data data frame with columns
 #' "location" and "population". Default: [population_data].
-#' @param excluded_locations character vector of location
-#' codes to exclude from the output. Default: character(0).
+#' @param excluded_locations character vector of US state
+#' abbreviations to exclude from the output across all
+#' targets. Default: character(0).
+#' @param excluded_locations_by_target named list mapping
+#' target names to character vectors of US state
+#' abbreviations to exclude for that target only.
+#' Default: list().
 #' @param output_format character, output file format. One
 #' of "csv", "tsv", or "parquet". Default: "csv".
 #' @param targets character vector, target name(s) to
 #' filter forecasts. If NULL (default), does not filter by
 #' target.
+#' @param overwrite_existing logical. If TRUE, overwrite
+#' existing files. Default: FALSE.
 #'
 #' @return invisibly returns the file path where data was
 #' written
@@ -209,8 +242,10 @@ write_ref_date_summary_all <- function(
   horizons_to_include = c(0, 1, 2),
   population_data = hubhelpr::population_data,
   excluded_locations = character(0),
+  excluded_locations_by_target = list(),
   output_format = "csv",
-  targets = NULL
+  targets = NULL,
+  overwrite_existing = FALSE
 ) {
   all_models_columns <- c(
     "location_name",
@@ -244,10 +279,12 @@ write_ref_date_summary_all <- function(
     file_suffix = "forecasts_data",
     horizons_to_include = horizons_to_include,
     excluded_locations = excluded_locations,
+    excluded_locations_by_target = excluded_locations_by_target,
     output_format = output_format,
     targets = targets,
     model_ids = NULL,
     population_data = population_data,
-    column_selection = all_models_columns
+    column_selection = all_models_columns,
+    overwrite_existing = overwrite_existing
   )
 }

--- a/R/write_ref_date_summary.R
+++ b/R/write_ref_date_summary.R
@@ -15,13 +15,12 @@
 #' filename (e.g., "map_data", "forecasts_data").
 #' @param horizons_to_include integer vector, horizons to
 #' include in the output. Default: c(0, 1, 2).
-#' @param excluded_locations character vector of US state
-#' abbreviations to exclude from the output across all
-#' targets. Default: character(0).
-#' @param excluded_locations_by_target named list mapping
-#' target names to character vectors of US state
-#' abbreviations to exclude for that target only.
-#' Default: list().
+#' @param excluded_locations character vector or named list
+#' specifying US state abbreviations to exclude. If a
+#' character vector, locations are excluded across all
+#' targets. If a named list, names should be target names
+#' (or "all" for global exclusions) mapping to character
+#' vectors of abbreviations. Default: NULL.
 #' @param output_format character, output file format. One
 #' of "csv", "tsv", or "parquet". Default: "csv".
 #' @param targets character vector, target name(s) to
@@ -48,8 +47,7 @@ write_ref_date_summary <- function(
   disease,
   file_suffix,
   horizons_to_include = c(0, 1, 2),
-  excluded_locations = character(0),
-  excluded_locations_by_target = list(),
+  excluded_locations = NULL,
   output_format = "csv",
   targets = NULL,
   model_ids = NULL,
@@ -66,7 +64,6 @@ write_ref_date_summary <- function(
     population_data = population_data,
     horizons_to_include = horizons_to_include,
     excluded_locations = excluded_locations,
-    excluded_locations_by_target = excluded_locations_by_target,
     targets = targets,
     model_ids = model_ids
   )
@@ -120,13 +117,12 @@ write_ref_date_summary <- function(
 #' include in the output. Default: c(0, 1, 2).
 #' @param population_data data frame with columns
 #' "location" and "population". Default: population_data.
-#' @param excluded_locations character vector of US state
-#' abbreviations to exclude from the output across all
-#' targets. Default: character(0).
-#' @param excluded_locations_by_target named list mapping
-#' target names to character vectors of US state
-#' abbreviations to exclude for that target only.
-#' Default: list().
+#' @param excluded_locations character vector or named list
+#' specifying US state abbreviations to exclude. If a
+#' character vector, locations are excluded across all
+#' targets. If a named list, names should be target names
+#' (or "all" for global exclusions) mapping to character
+#' vectors of abbreviations. Default: NULL.
 #' @param output_format character, output file format. One
 #' of "csv", "tsv", or "parquet". Default: "csv".
 #' @param targets character vector, target name(s) to
@@ -146,8 +142,7 @@ write_ref_date_summary_ens <- function(
   disease,
   horizons_to_include = c(0, 1, 2),
   population_data = hubhelpr::population_data,
-  excluded_locations = character(0),
-  excluded_locations_by_target = list(),
+  excluded_locations = NULL,
   output_format = "csv",
   targets = NULL,
   overwrite_existing = FALSE
@@ -189,7 +184,6 @@ write_ref_date_summary_ens <- function(
     file_suffix = "map_data",
     horizons_to_include = horizons_to_include,
     excluded_locations = excluded_locations,
-    excluded_locations_by_target = excluded_locations_by_target,
     output_format = output_format,
     targets = targets,
     model_ids = ensemble_model_name,
@@ -215,13 +209,12 @@ write_ref_date_summary_ens <- function(
 #' include in the output. Default: c(0, 1, 2).
 #' @param population_data data frame with columns
 #' "location" and "population". Default: [population_data].
-#' @param excluded_locations character vector of US state
-#' abbreviations to exclude from the output across all
-#' targets. Default: character(0).
-#' @param excluded_locations_by_target named list mapping
-#' target names to character vectors of US state
-#' abbreviations to exclude for that target only.
-#' Default: list().
+#' @param excluded_locations character vector or named list
+#' specifying US state abbreviations to exclude. If a
+#' character vector, locations are excluded across all
+#' targets. If a named list, names should be target names
+#' (or "all" for global exclusions) mapping to character
+#' vectors of abbreviations. Default: NULL.
 #' @param output_format character, output file format. One
 #' of "csv", "tsv", or "parquet". Default: "csv".
 #' @param targets character vector, target name(s) to
@@ -241,8 +234,7 @@ write_ref_date_summary_all <- function(
   disease,
   horizons_to_include = c(0, 1, 2),
   population_data = hubhelpr::population_data,
-  excluded_locations = character(0),
-  excluded_locations_by_target = list(),
+  excluded_locations = NULL,
   output_format = "csv",
   targets = NULL,
   overwrite_existing = FALSE
@@ -279,7 +271,6 @@ write_ref_date_summary_all <- function(
     file_suffix = "forecasts_data",
     horizons_to_include = horizons_to_include,
     excluded_locations = excluded_locations,
-    excluded_locations_by_target = excluded_locations_by_target,
     output_format = output_format,
     targets = targets,
     model_ids = NULL,

--- a/R/write_viz_target_data.R
+++ b/R/write_viz_target_data.R
@@ -38,6 +38,8 @@
 #' hubhelpr::included_locations.
 #' @param output_format Character, output file format. One
 #' of "csv", "tsv", or "parquet". Default: "csv".
+#' @param overwrite_existing logical. If TRUE, overwrite
+#' existing files. Default: FALSE.
 #'
 #' @return Invisibly returns file path where data was
 #' written.
@@ -55,7 +57,8 @@ write_viz_target_data <- function(
   start_date = NULL,
   end_date = NULL,
   included_locations = hubhelpr::included_locations,
-  output_format = "csv"
+  output_format = "csv",
+  overwrite_existing = FALSE
 ) {
   if (use_hub_data) {
     target_data <- hubData::connect_target_timeseries(base_hub_path) |>
@@ -140,6 +143,15 @@ write_viz_target_data <- function(
   )
 
   fs::dir_create(output_folder_path)
+
+  if (fs::file_exists(output_filepath) && !overwrite_existing) {
+    cli::cli_abort(
+      c(
+        "File already exists: {output_filepath}.",
+        "i" = "Use {.arg overwrite_existing = TRUE} to overwrite."
+      )
+    )
+  }
 
   forecasttools::write_tabular(target_data, output_filepath)
   cli::cli_inform("File saved as: {output_filepath}.")

--- a/R/write_viz_target_data.R
+++ b/R/write_viz_target_data.R
@@ -141,12 +141,8 @@ write_viz_target_data <- function(
 
   fs::dir_create(output_folder_path)
 
-  if (!fs::file_exists(output_filepath)) {
-    forecasttools::write_tabular(target_data, output_filepath)
-    cli::cli_inform("File saved as: {output_filepath}.")
-  } else {
-    cli::cli_abort("File already exists: {output_filepath}.")
-  }
+  forecasttools::write_tabular(target_data, output_filepath)
+  cli::cli_inform("File saved as: {output_filepath}.")
 
   invisible(output_filepath)
 }

--- a/R/write_webtext.R
+++ b/R/write_webtext.R
@@ -459,6 +459,8 @@ generate_webtext_block <- function(
 #' @param input_format Character, input file format for
 #' reading summary data files. One of "csv", "tsv", or
 #' "parquet". Default: "csv".
+#' @param overwrite_existing logical. If TRUE, overwrite
+#' existing files. Default: FALSE.
 #'
 #' @export
 write_webtext <- function(
@@ -468,7 +470,8 @@ write_webtext <- function(
   hub_reports_path,
   targets = NULL,
   included_locations = hubhelpr::included_locations,
-  input_format = "csv"
+  input_format = "csv",
+  overwrite_existing = FALSE
 ) {
   reference_date <- lubridate::as_date(reference_date)
 
@@ -498,6 +501,15 @@ write_webtext <- function(
     glue::glue("{reference_date}_{disease}_webtext"),
     ext = "md"
   )
+
+  if (fs::file_exists(output_path) && !overwrite_existing) {
+    cli::cli_abort(
+      c(
+        "File already exists: {output_path}.",
+        "i" = "Use {.arg overwrite_existing = TRUE} to overwrite."
+      )
+    )
+  }
 
   writeLines(web_text, output_path)
   cli::cli_inform("Webtext saved as: {output_path}.")

--- a/R/write_webtext.R
+++ b/R/write_webtext.R
@@ -499,10 +499,6 @@ write_webtext <- function(
     ext = "md"
   )
 
-  if (fs::file_exists(output_path)) {
-    cli::cli_abort("File already exists: {output_path}.")
-  }
-
   writeLines(web_text, output_path)
   cli::cli_inform("Webtext saved as: {output_path}.")
 

--- a/man/summarize_ref_date_forecasts.Rd
+++ b/man/summarize_ref_date_forecasts.Rd
@@ -11,6 +11,7 @@ summarize_ref_date_forecasts(
   population_data,
   horizons_to_include = c(0, 1, 2),
   excluded_locations = character(0),
+  excluded_locations_by_target = list(),
   targets = NULL,
   model_ids = NULL
 )
@@ -31,8 +32,15 @@ and "population". Adds population-based calculations.}
 \item{horizons_to_include}{integer vector, horizons to
 include in the output. Default: c(0, 1, 2).}
 
-\item{excluded_locations}{character vector of location
-codes to exclude from the output. Default: character(0).}
+\item{excluded_locations}{character vector of US state
+abbreviations to exclude from the output across all
+targets. Converted to hub codes internally. Default:
+character(0).}
+
+\item{excluded_locations_by_target}{named list mapping
+target names to character vectors of US state
+abbreviations to exclude for that target only. Default:
+list().}
 
 \item{targets}{character vector, target name(s) to filter
 forecasts. If NULL (default), does not filter by target.}

--- a/man/summarize_ref_date_forecasts.Rd
+++ b/man/summarize_ref_date_forecasts.Rd
@@ -10,8 +10,7 @@ summarize_ref_date_forecasts(
   disease,
   population_data,
   horizons_to_include = c(0, 1, 2),
-  excluded_locations = character(0),
-  excluded_locations_by_target = list(),
+  excluded_locations = NULL,
   targets = NULL,
   model_ids = NULL
 )
@@ -32,15 +31,13 @@ and "population". Adds population-based calculations.}
 \item{horizons_to_include}{integer vector, horizons to
 include in the output. Default: c(0, 1, 2).}
 
-\item{excluded_locations}{character vector of US state
-abbreviations to exclude from the output across all
-targets. Converted to hub codes internally. Default:
-character(0).}
-
-\item{excluded_locations_by_target}{named list mapping
-target names to character vectors of US state
-abbreviations to exclude for that target only. Default:
-list().}
+\item{excluded_locations}{character vector or named list
+specifying US state abbreviations to exclude. If a
+character vector, locations are excluded across all
+targets. If a named list, names should be target names
+(or "all" for global exclusions) mapping to character
+vectors of abbreviations. Converted to hub codes
+internally. Default: NULL.}
 
 \item{targets}{character vector, target name(s) to filter
 forecasts. If NULL (default), does not filter by target.}

--- a/man/write_ref_date_summary.Rd
+++ b/man/write_ref_date_summary.Rd
@@ -12,11 +12,13 @@ write_ref_date_summary(
   file_suffix,
   horizons_to_include = c(0, 1, 2),
   excluded_locations = character(0),
+  excluded_locations_by_target = list(),
   output_format = "csv",
   targets = NULL,
   model_ids = NULL,
   population_data,
-  column_selection = tidyselect::everything()
+  column_selection = tidyselect::everything(),
+  overwrite_existing = FALSE
 )
 }
 \arguments{
@@ -38,8 +40,14 @@ filename (e.g., "map_data", "forecasts_data").}
 \item{horizons_to_include}{integer vector, horizons to
 include in the output. Default: c(0, 1, 2).}
 
-\item{excluded_locations}{character vector of location
-codes to exclude from the output. Default: character(0).}
+\item{excluded_locations}{character vector of US state
+abbreviations to exclude from the output across all
+targets. Default: character(0).}
+
+\item{excluded_locations_by_target}{named list mapping
+target names to character vectors of US state
+abbreviations to exclude for that target only.
+Default: list().}
 
 \item{output_format}{character, output file format. One
 of "csv", "tsv", or "parquet". Default: "csv".}
@@ -57,6 +65,9 @@ include. If NULL (default), includes all models.}
 \item{column_selection}{Columns to include in the output
 table. Accepts tidyselect expressions. Default:
 \code{\link[tidyselect:everything]{tidyselect::everything()}}.}
+
+\item{overwrite_existing}{logical. If TRUE, overwrite
+existing files. Default: FALSE.}
 }
 \value{
 invisibly returns the file path where data was

--- a/man/write_ref_date_summary.Rd
+++ b/man/write_ref_date_summary.Rd
@@ -11,8 +11,7 @@ write_ref_date_summary(
   disease,
   file_suffix,
   horizons_to_include = c(0, 1, 2),
-  excluded_locations = character(0),
-  excluded_locations_by_target = list(),
+  excluded_locations = NULL,
   output_format = "csv",
   targets = NULL,
   model_ids = NULL,
@@ -40,14 +39,12 @@ filename (e.g., "map_data", "forecasts_data").}
 \item{horizons_to_include}{integer vector, horizons to
 include in the output. Default: c(0, 1, 2).}
 
-\item{excluded_locations}{character vector of US state
-abbreviations to exclude from the output across all
-targets. Default: character(0).}
-
-\item{excluded_locations_by_target}{named list mapping
-target names to character vectors of US state
-abbreviations to exclude for that target only.
-Default: list().}
+\item{excluded_locations}{character vector or named list
+specifying US state abbreviations to exclude. If a
+character vector, locations are excluded across all
+targets. If a named list, names should be target names
+(or "all" for global exclusions) mapping to character
+vectors of abbreviations. Default: NULL.}
 
 \item{output_format}{character, output file format. One
 of "csv", "tsv", or "parquet". Default: "csv".}

--- a/man/write_ref_date_summary_all.Rd
+++ b/man/write_ref_date_summary_all.Rd
@@ -12,8 +12,10 @@ write_ref_date_summary_all(
   horizons_to_include = c(0, 1, 2),
   population_data = hubhelpr::population_data,
   excluded_locations = character(0),
+  excluded_locations_by_target = list(),
   output_format = "csv",
-  targets = NULL
+  targets = NULL,
+  overwrite_existing = FALSE
 )
 }
 \arguments{
@@ -34,8 +36,14 @@ include in the output. Default: c(0, 1, 2).}
 \item{population_data}{data frame with columns
 "location" and "population". Default: \link{population_data}.}
 
-\item{excluded_locations}{character vector of location
-codes to exclude from the output. Default: character(0).}
+\item{excluded_locations}{character vector of US state
+abbreviations to exclude from the output across all
+targets. Default: character(0).}
+
+\item{excluded_locations_by_target}{named list mapping
+target names to character vectors of US state
+abbreviations to exclude for that target only.
+Default: list().}
 
 \item{output_format}{character, output file format. One
 of "csv", "tsv", or "parquet". Default: "csv".}
@@ -43,6 +51,9 @@ of "csv", "tsv", or "parquet". Default: "csv".}
 \item{targets}{character vector, target name(s) to
 filter forecasts. If NULL (default), does not filter by
 target.}
+
+\item{overwrite_existing}{logical. If TRUE, overwrite
+existing files. Default: FALSE.}
 }
 \value{
 invisibly returns the file path where data was

--- a/man/write_ref_date_summary_all.Rd
+++ b/man/write_ref_date_summary_all.Rd
@@ -11,8 +11,7 @@ write_ref_date_summary_all(
   disease,
   horizons_to_include = c(0, 1, 2),
   population_data = hubhelpr::population_data,
-  excluded_locations = character(0),
-  excluded_locations_by_target = list(),
+  excluded_locations = NULL,
   output_format = "csv",
   targets = NULL,
   overwrite_existing = FALSE
@@ -36,14 +35,12 @@ include in the output. Default: c(0, 1, 2).}
 \item{population_data}{data frame with columns
 "location" and "population". Default: \link{population_data}.}
 
-\item{excluded_locations}{character vector of US state
-abbreviations to exclude from the output across all
-targets. Default: character(0).}
-
-\item{excluded_locations_by_target}{named list mapping
-target names to character vectors of US state
-abbreviations to exclude for that target only.
-Default: list().}
+\item{excluded_locations}{character vector or named list
+specifying US state abbreviations to exclude. If a
+character vector, locations are excluded across all
+targets. If a named list, names should be target names
+(or "all" for global exclusions) mapping to character
+vectors of abbreviations. Default: NULL.}
 
 \item{output_format}{character, output file format. One
 of "csv", "tsv", or "parquet". Default: "csv".}

--- a/man/write_ref_date_summary_ens.Rd
+++ b/man/write_ref_date_summary_ens.Rd
@@ -12,8 +12,10 @@ write_ref_date_summary_ens(
   horizons_to_include = c(0, 1, 2),
   population_data = hubhelpr::population_data,
   excluded_locations = character(0),
+  excluded_locations_by_target = list(),
   output_format = "csv",
-  targets = NULL
+  targets = NULL,
+  overwrite_existing = FALSE
 )
 }
 \arguments{
@@ -34,8 +36,14 @@ include in the output. Default: c(0, 1, 2).}
 \item{population_data}{data frame with columns
 "location" and "population". Default: population_data.}
 
-\item{excluded_locations}{character vector of location
-codes to exclude from the output. Default: character(0).}
+\item{excluded_locations}{character vector of US state
+abbreviations to exclude from the output across all
+targets. Default: character(0).}
+
+\item{excluded_locations_by_target}{named list mapping
+target names to character vectors of US state
+abbreviations to exclude for that target only.
+Default: list().}
 
 \item{output_format}{character, output file format. One
 of "csv", "tsv", or "parquet". Default: "csv".}
@@ -43,6 +51,9 @@ of "csv", "tsv", or "parquet". Default: "csv".}
 \item{targets}{character vector, target name(s) to
 filter forecasts. If NULL (default), does not filter by
 target.}
+
+\item{overwrite_existing}{logical. If TRUE, overwrite
+existing files. Default: FALSE.}
 }
 \value{
 invisibly returns the file path where data was

--- a/man/write_ref_date_summary_ens.Rd
+++ b/man/write_ref_date_summary_ens.Rd
@@ -11,8 +11,7 @@ write_ref_date_summary_ens(
   disease,
   horizons_to_include = c(0, 1, 2),
   population_data = hubhelpr::population_data,
-  excluded_locations = character(0),
-  excluded_locations_by_target = list(),
+  excluded_locations = NULL,
   output_format = "csv",
   targets = NULL,
   overwrite_existing = FALSE
@@ -36,14 +35,12 @@ include in the output. Default: c(0, 1, 2).}
 \item{population_data}{data frame with columns
 "location" and "population". Default: population_data.}
 
-\item{excluded_locations}{character vector of US state
-abbreviations to exclude from the output across all
-targets. Default: character(0).}
-
-\item{excluded_locations_by_target}{named list mapping
-target names to character vectors of US state
-abbreviations to exclude for that target only.
-Default: list().}
+\item{excluded_locations}{character vector or named list
+specifying US state abbreviations to exclude. If a
+character vector, locations are excluded across all
+targets. If a named list, names should be target names
+(or "all" for global exclusions) mapping to character
+vectors of abbreviations. Default: NULL.}
 
 \item{output_format}{character, output file format. One
 of "csv", "tsv", or "parquet". Default: "csv".}

--- a/man/write_viz_target_data.Rd
+++ b/man/write_viz_target_data.Rd
@@ -16,7 +16,8 @@ write_viz_target_data(
   start_date = NULL,
   end_date = NULL,
   included_locations = hubhelpr::included_locations,
-  output_format = "csv"
+  output_format = "csv",
+  overwrite_existing = FALSE
 )
 }
 \arguments{
@@ -62,6 +63,9 @@ hubhelpr::included_locations.}
 
 \item{output_format}{Character, output file format. One
 of "csv", "tsv", or "parquet". Default: "csv".}
+
+\item{overwrite_existing}{logical. If TRUE, overwrite
+existing files. Default: FALSE.}
 }
 \value{
 Invisibly returns file path where data was

--- a/man/write_webtext.Rd
+++ b/man/write_webtext.Rd
@@ -12,7 +12,8 @@ write_webtext(
   hub_reports_path,
   targets = NULL,
   included_locations = hubhelpr::included_locations,
-  input_format = "csv"
+  input_format = "csv",
+  overwrite_existing = FALSE
 )
 }
 \arguments{
@@ -38,6 +39,9 @@ hubhelpr::included_locations.}
 \item{input_format}{Character, input file format for
 reading summary data files. One of "csv", "tsv", or
 "parquet". Default: "csv".}
+
+\item{overwrite_existing}{logical. If TRUE, overwrite
+existing files. Default: FALSE.}
 }
 \description{
 Generates formatted text summary for a single disease


### PR DESCRIPTION
This PR adds the capacity to overwrite of forecast summaries via the addition of an `overwrite_existing` argument to `write_ref_date_summary` (similar to `update_target_hub_data.R`) and adds the capacity to exclude locations for specific targets (via the argument `excluded_locations_by_target`).  