### PR TITLE
Allow Target And Location Specific Exclusions In Write-Vizualization-Data Function

### DIFF
--- a/R/write_viz_target_data.R
+++ b/R/write_viz_target_data.R
@@ -36,6 +36,13 @@
 #' @param included_locations Character vector of location
 #' codes to include in the output. Default
 #' hubhelpr::included_locations.
+#' @param excluded_locations Character vector or named list
+#' specifying US state abbreviations to exclude. If a
+#' character vector, locations are excluded across all
+#' targets. If a named list, names should be target names
+#' (or "all" for global exclusions) mapping to character
+#' vectors of abbreviations. Converted to hub codes
+#' internally. Default: NULL.
 #' @param output_format Character, output file format. One
 #' of "csv", "tsv", or "parquet". Default: "csv".
 #' @param overwrite_existing logical. If TRUE, overwrite
@@ -57,6 +64,7 @@ write_viz_target_data <- function(
   start_date = NULL,
   end_date = NULL,
   included_locations = hubhelpr::included_locations,
+  excluded_locations = NULL,
   output_format = "csv",
   overwrite_existing = FALSE
 ) {
@@ -103,6 +111,13 @@ write_viz_target_data <- function(
     }
     target_data <- dplyr::bind_rows(nhsn_data, nssp_data)
   }
+
+  excluded_locations <- normalize_excluded_locations(excluded_locations)
+  supported_targets <- get_hub_supported_targets(base_hub_path)
+  exclusion_df <- build_exclusion_df(excluded_locations, supported_targets)
+
+  target_data <- target_data |>
+    dplyr::anti_join(exclusion_df, by = c("target", "location"))
 
   target_data <- target_data |>
     dplyr::mutate(

--- a/man/write_viz_target_data.Rd
+++ b/man/write_viz_target_data.Rd
@@ -16,6 +16,7 @@ write_viz_target_data(
   start_date = NULL,
   end_date = NULL,
   included_locations = hubhelpr::included_locations,
+  excluded_locations = NULL,
   output_format = "csv",
   overwrite_existing = FALSE
 )
@@ -60,6 +61,14 @@ use_hub_data = FALSE.}
 \item{included_locations}{Character vector of location
 codes to include in the output. Default
 hubhelpr::included_locations.}
+
+\item{excluded_locations}{Character vector or named list
+specifying US state abbreviations to exclude. If a
+character vector, locations are excluded across all
+targets. If a named list, names should be target names
+(or "all" for global exclusions) mapping to character
+vectors of abbreviations. Converted to hub codes
+internally. Default: NULL.}
 
 \item{output_format}{Character, output file format. One
 of "csv", "tsv", or "parquet". Default: "csv".}


### PR DESCRIPTION
This PR adopts the exclusion pattern from `summarize_ref_date_forecasts.R`

```r
supported_targets <- get_hub_supported_targets(base_hub_path)
exclusion_df <- build_exclusion_df(
  excluded_locations, supported_targets)

current_forecasts <- current_forecasts |>
  dplyr::anti_join(
    exclusion_df, by = c("target", "location"))
```

in the function `write_viz_target_data`. 