### PR TITLE
Update Visualization Data Action To Use Exclusions

### DIFF
--- a/actions/generate-viz-data/action.yaml
+++ b/actions/generate-viz-data/action.yaml
@@ -28,9 +28,9 @@ inputs:
     required: false
     default: ""
   excluded_locations:
-    description: "JSON array of US state/territory abbreviations to exclude from output (e.g., '[\"VI\", \"GU\", \"AS\", \"MP\", \"UM\"]'). Defaults to no exclusions."
+    description: "JSON array of US state/territory abbreviations to exclude from output (e.g., '[\"VI\", \"GU\", \"AS\", \"MP\", \"UM\"]'). Also accepts a JSON object for target-specific exclusions (e.g., '{\"all\": [\"UM\"], \"wk inc covid hosp\": [\"MA\"]}'). Defaults to no exclusions."
     required: false
-    default: ""
+    default: "[]"
 
 runs:
   using: "composite"
@@ -58,12 +58,9 @@ runs:
           targets <- jsonlite::fromJSON(input_targets)
         }
 
-        input_excluded <- '${{ inputs.excluded_locations }}'
-        if (nchar(input_excluded) == 0) {
-          excluded_locations <- NULL
-        } else {
-          excluded_locations <- jsonlite::fromJSON(input_excluded)
-        }
+        excluded_locations <- jsonlite::fromJSON(
+          '${{ inputs.excluded_locations }}'
+        )
 
         hubhelpr::write_ref_date_summary_ens(
           reference_date = ref_date,


### PR DESCRIPTION
This PR updates `hubhelpr/actions/generate-viz-data/action.yaml` to use an `excluded_locations` input and passes this to `write_ref_date_summary_ens()`, `write_ref_date_summary_all()`, and `write_viz_target_data()`.