### PR TITLE
Add explicit filter to quantile output types in preparation for samples submission

### DIFF
--- a/R/count_designated_models.R
+++ b/R/count_designated_models.R
@@ -18,7 +18,8 @@
 #' @param horizons integer vector of horizons to include.
 #' If NULL (default), includes all available horizons.
 #' @param output_types character vector of output types
-#' to include. Default: "quantile".
+#' to include. If NULL (default), includes all available
+#' output types.
 #'
 #' @return A tibble with columns `reference_date`,
 #' `target`, `location`, `horizon`, `output_type`,
@@ -30,7 +31,7 @@ count_designated_models <- function(
   reference_dates = NULL,
   targets = NULL,
   horizons = NULL,
-  output_types = "quantile"
+  output_types = NULL
 ) {
   hub_forecasts <- hubData::connect_hub(base_hub_path)
 

--- a/R/count_designated_models.R
+++ b/R/count_designated_models.R
@@ -18,8 +18,8 @@
 #' @param horizons integer vector of horizons to include.
 #' If NULL (default), includes all available horizons.
 #' @param output_types character vector of output types
-#' to include. If NULL (default), includes all available
-#' output types.
+#' to include. Default: NULL (include all available
+#' output types).
 #'
 #' @return A tibble with columns `reference_date`,
 #' `target`, `location`, `horizon`, `output_type`,

--- a/R/summarize_ref_date_forecasts.R
+++ b/R/summarize_ref_date_forecasts.R
@@ -122,6 +122,7 @@ summarize_ref_date_forecasts <- function(
   current_forecasts <- hub_content |>
     dplyr::filter(
       .data$reference_date == !!reference_date,
+      .data$output_type == "quantile",
       .data$horizon %in% !!horizons_to_include
     ) |>
     hubData::collect_hub() |>

--- a/R/write_ref_date_summary.R
+++ b/R/write_ref_date_summary.R
@@ -159,7 +159,8 @@ write_ref_date_summary_ens <- function(
     reference_dates = reference_date,
     base_hub_path = base_hub_path,
     targets = targets,
-    horizons = horizons_to_include
+    horizons = horizons_to_include,
+    output_types = c("quantile")
   ) |>
     dplyr::filter(.data$n_models >= !!n_models_for_reporting) |>
     dplyr::select(-"n_models")

--- a/man/count_designated_models.Rd
+++ b/man/count_designated_models.Rd
@@ -10,7 +10,7 @@ count_designated_models(
   reference_dates = NULL,
   targets = NULL,
   horizons = NULL,
-  output_types = "quantile"
+  output_types = NULL
 )
 }
 \arguments{
@@ -29,7 +29,8 @@ targets.}
 If NULL (default), includes all available horizons.}
 
 \item{output_types}{character vector of output types
-to include. Default: "quantile".}
+to include. If NULL (default), includes all available
+output types.}
 }
 \value{
 A tibble with columns \code{reference_date},


### PR DESCRIPTION
`R/summarize_ref_date_forecasts.R` - `forecasttools::pivot_hubverse_quantiles_wider` filters before pivoting but I think the explicit step is better for calrity