### PR TITLE
Adopt Some Minor Refactorings

### DIFF
--- a/R/check_changes_for_autoapproval.R
+++ b/R/check_changes_for_autoapproval.R
@@ -59,8 +59,8 @@ check_changes_for_autoapproval <- function(
   }
   changed_model_ids <- changed_files_tbl |>
     dplyr::filter(.data$in_model_output) |>
-    dplyr::pull(.data$model_id) |>
-    unique()
+    dplyr::distinct(.data$model_id) |>
+    dplyr::pull(.data$model_id)
 
   if (length(changed_model_ids) > 0) {
     cli::cli_inform(

--- a/R/generate_hub_baselines.R
+++ b/R/generate_hub_baselines.R
@@ -141,7 +141,7 @@ generate_hub_baseline <- function(
   as_of = "latest",
   output_format = "csv"
 ) {
-  rlang::arg_match(disease, c("covid", "rsv"))
+  checkmate::assert_choice(disease, choices = c("covid", "rsv"))
   reference_date <- lubridate::as_date(reference_date)
   desired_max_time_value <- reference_date - lubridate::weeks(1)
   dow_supplied <- lubridate::wday(reference_date, week_start = 7, label = FALSE)

--- a/R/generate_hub_baselines.R
+++ b/R/generate_hub_baselines.R
@@ -141,7 +141,7 @@ generate_hub_baseline <- function(
   as_of = "latest",
   output_format = "csv"
 ) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv"))
+  rlang::arg_match(disease, c("covid", "rsv"))
   reference_date <- lubridate::as_date(reference_date)
   desired_max_time_value <- reference_date - lubridate::weeks(1)
   dow_supplied <- lubridate::wday(reference_date, week_start = 7, label = FALSE)

--- a/R/generate_hub_baselines.R
+++ b/R/generate_hub_baselines.R
@@ -148,12 +148,10 @@ generate_hub_baseline <- function(
   rng_seed <- as.integer((59460707 + as.numeric(reference_date)) %% 2e9)
   if (dow_supplied != 7) {
     cli::cli_abort(
-      message = paste0(
-        "Expected `reference_date` to be a Saturday, day number 7 ",
-        "of the week, given the `week_start` value of Sunday. ",
-        "Got {reference_date}, which is day number ",
-        "{dow_supplied} of the week."
-      )
+      "Expected {.arg reference_date} to be a Saturday, day number 7
+      of the week, given the {.arg week_start} value of Sunday.
+      Got {reference_date}, which is day number
+      {dow_supplied} of the week."
     )
   }
 

--- a/R/generate_hub_ensemble.R
+++ b/R/generate_hub_ensemble.R
@@ -94,7 +94,7 @@ generate_hub_ensemble <- function(
   targets = NULL,
   output_format = "csv"
 ) {
-  rlang::arg_match(disease, c("covid", "rsv"))
+  checkmate::assert_choice(disease, choices = c("covid", "rsv"))
   reference_date <- lubridate::as_date(reference_date)
 
   dow_supplied <- lubridate::wday(reference_date, week_start = 7, label = FALSE)

--- a/R/generate_hub_ensemble.R
+++ b/R/generate_hub_ensemble.R
@@ -41,7 +41,9 @@ ensemble_by_target <- function(
   )
 
   if (ensemble_output_type != "quantile") {
-    stop("Only 'quantile' ensemble_output_type is currently supported")
+    cli::cli_abort(
+      "Only {.val quantile} {.arg ensemble_output_type} is currently supported."
+    )
   }
 
   eligible_models <- weekly_models |>
@@ -98,12 +100,10 @@ generate_hub_ensemble <- function(
   dow_supplied <- lubridate::wday(reference_date, week_start = 7, label = FALSE)
   if (dow_supplied != 7) {
     cli::cli_abort(
-      message = paste0(
-        "Expected `reference_date` to be a Saturday, day number 7 ",
-        "of the week, given the `week_start` value of Sunday. ",
-        "Got {reference_date}, which is day number ",
-        "{dow_supplied} of the week."
-      )
+      "Expected {.arg reference_date} to be a Saturday, day number 7
+      of the week, given the {.arg week_start} value of Sunday.
+      Got {reference_date}, which is day number
+      {dow_supplied} of the week."
     )
   }
 

--- a/R/generate_hub_ensemble.R
+++ b/R/generate_hub_ensemble.R
@@ -92,7 +92,7 @@ generate_hub_ensemble <- function(
   targets = NULL,
   output_format = "csv"
 ) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv"))
+  rlang::arg_match(disease, c("covid", "rsv"))
   reference_date <- lubridate::as_date(reference_date)
 
   dow_supplied <- lubridate::wday(reference_date, week_start = 7, label = FALSE)

--- a/R/summarize_ref_date_forecasts.R
+++ b/R/summarize_ref_date_forecasts.R
@@ -139,7 +139,11 @@ summarize_ref_date_forecasts <- function(
         .names = "{.col}_rounded"
       ),
       forecast_due_date = as.Date(!!reference_date) - 3,
-      location_sort_order = ifelse(.data$location_name == "United States", 0, 1)
+      location_sort_order = dplyr::if_else(
+        .data$location_name == "United States",
+        0L,
+        1L
+      )
       # order table with national first, then alphabetically
     ) |>
     dplyr::arrange(.data$location_sort_order, .data$location_name) |>

--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -84,7 +84,7 @@ get_hubverse_format_nhsn_data <- function(
   start_date = NULL,
   end_date = NULL
 ) {
-  rlang::arg_match(disease, c("covid", "rsv", "flu"))
+  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
 
   nhsn_col_name <- get_nhsn_col_name(disease)
 
@@ -139,7 +139,7 @@ get_hubverse_format_nssp_data <- function(
   start_date = NULL,
   end_date = NULL
 ) {
-  rlang::arg_match(disease, c("covid", "rsv", "flu"))
+  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
 
   nssp_col_name <- get_nssp_col_name(disease)
 
@@ -236,7 +236,7 @@ update_hub_target_data <- function(
   nssp_update_local = FALSE,
   overwrite_existing = FALSE
 ) {
-  rlang::arg_match(disease, c("covid", "rsv"))
+  checkmate::assert_choice(disease, choices = c("covid", "rsv"))
 
   nhsn_data <- get_hubverse_format_nhsn_data(
     disease,

--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -285,7 +285,7 @@ update_hub_target_data <- function(
       "{disease}-hospital-admissions.csv"
     )
     filtered_hosp_data <- filtered_target_data |>
-      dplyr::filter(grepl("hosp$", .data$target))
+      dplyr::filter(is_hosp_target(.data$target))
     filtered_hosp_data |>
       dplyr::mutate(
         state = forecasttools::us_location_recode(

--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -84,7 +84,7 @@ get_hubverse_format_nhsn_data <- function(
   start_date = NULL,
   end_date = NULL
 ) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
+  rlang::arg_match(disease, c("covid", "rsv", "flu"))
 
   nhsn_col_name <- get_nhsn_col_name(disease)
 
@@ -139,7 +139,7 @@ get_hubverse_format_nssp_data <- function(
   start_date = NULL,
   end_date = NULL
 ) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
+  rlang::arg_match(disease, c("covid", "rsv", "flu"))
 
   nssp_col_name <- get_nssp_col_name(disease)
 
@@ -236,7 +236,7 @@ update_hub_target_data <- function(
   nssp_update_local = FALSE,
   overwrite_existing = FALSE
 ) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv"))
+  rlang::arg_match(disease, c("covid", "rsv"))
 
   nhsn_data <- get_hubverse_format_nhsn_data(
     disease,

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,16 +1,49 @@
+# named vectors for disease-to-value mappings
+nhsn_col_names <- c(
+  covid = "totalconfc19newadm",
+  rsv = "totalconfrsvnewadm",
+  flu = "totalconfflunewadm"
+)
+
+nssp_col_names <- c(
+  covid = "percent_visits_covid",
+  rsv = "percent_visits_rsv",
+  flu = "percent_visits_flu"
+)
+
+hub_names <- c(
+  covid = "CovidHub",
+  rsv = "RSVHub",
+  flu = "FluSight"
+)
+
+hub_repo_names <- c(
+  covid = "covid19-forecast-hub",
+  rsv = "rsv-forecast-hub",
+  flu = "FluSight-forecast-hub"
+)
+
+hub_repo_owners <- c(
+  covid = "CDCgov",
+  rsv = "CDCgov",
+  flu = "cdcepi"
+)
+
+disease_display_names <- c(
+  covid = "COVID-19",
+  rsv = "RSV",
+  flu = "Influenza"
+)
+
+
 #' Get NHSN column name for a given disease
 #'
 #' @param disease Disease name ("covid", "rsv", or "flu")
 #' @return Character string with the NHSN column name
 #' @export
 get_nhsn_col_name <- function(disease) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
-
-  dplyr::case_when(
-    disease == "covid" ~ "totalconfc19newadm",
-    disease == "rsv" ~ "totalconfrsvnewadm",
-    disease == "flu" ~ "totalconfflunewadm"
-  )
+  rlang::arg_match(disease, names(nhsn_col_names))
+  unname(nhsn_col_names[disease])
 }
 
 #' Get NSSP column name for a given disease
@@ -19,13 +52,8 @@ get_nhsn_col_name <- function(disease) {
 #' @return Character string with the NSSP column name
 #' @export
 get_nssp_col_name <- function(disease) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
-
-  dplyr::case_when(
-    disease == "covid" ~ "percent_visits_covid",
-    disease == "rsv" ~ "percent_visits_rsv",
-    disease == "flu" ~ "percent_visits_flu"
-  )
+  rlang::arg_match(disease, names(nssp_col_names))
+  unname(nssp_col_names[disease])
 }
 
 
@@ -39,12 +67,8 @@ get_nssp_col_name <- function(disease) {
 #' @return Character. Hub name (e.g., "CovidHub", "RSVHub", "FluSight").
 #' @export
 get_hub_name <- function(disease) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
-  dplyr::case_when(
-    disease == "covid" ~ "CovidHub",
-    disease == "rsv" ~ "RSVHub",
-    disease == "flu" ~ "FluSight"
-  )
+  rlang::arg_match(disease, names(hub_names))
+  unname(hub_names[disease])
 }
 
 
@@ -58,13 +82,8 @@ get_hub_name <- function(disease) {
 #' @return Character. GitHub repository name.
 #' @export
 get_hub_repo_name <- function(disease) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
-
-  dplyr::case_when(
-    disease == "covid" ~ "covid19-forecast-hub",
-    disease == "rsv" ~ "rsv-forecast-hub",
-    disease == "flu" ~ "FluSight-forecast-hub"
-  )
+  rlang::arg_match(disease, names(hub_repo_names))
+  unname(hub_repo_names[disease])
 }
 
 
@@ -75,13 +94,8 @@ get_hub_repo_name <- function(disease) {
 #' @return Character. GitHub organization name.
 #' @noRd
 get_hub_repo_owner <- function(disease) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
-
-  dplyr::case_when(
-    disease == "covid" ~ "CDCgov",
-    disease == "rsv" ~ "CDCgov",
-    disease == "flu" ~ "cdcepi"
-  )
+  rlang::arg_match(disease, names(hub_repo_owners))
+  unname(hub_repo_owners[disease])
 }
 
 
@@ -112,13 +126,8 @@ get_hub_repo_url <- function(disease) {
 #' "Influenza").
 #' @export
 get_disease_name <- function(disease) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv", "flu"))
-
-  dplyr::case_when(
-    disease == "covid" ~ "COVID-19",
-    disease == "rsv" ~ "RSV",
-    disease == "flu" ~ "Influenza"
-  )
+  rlang::arg_match(disease, names(disease_display_names))
+  unname(disease_display_names[disease])
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,7 +43,7 @@ disease_display_names <- c(
 #' @export
 get_nhsn_col_name <- function(disease) {
   rlang::arg_match(disease, names(nhsn_col_names))
-  unname(nhsn_col_names[disease])
+  nhsn_col_names[[disease]]
 }
 
 #' Get NSSP column name for a given disease
@@ -53,7 +53,7 @@ get_nhsn_col_name <- function(disease) {
 #' @export
 get_nssp_col_name <- function(disease) {
   rlang::arg_match(disease, names(nssp_col_names))
-  unname(nssp_col_names[disease])
+  nssp_col_names[[disease]]
 }
 
 
@@ -68,7 +68,7 @@ get_nssp_col_name <- function(disease) {
 #' @export
 get_hub_name <- function(disease) {
   rlang::arg_match(disease, names(hub_names))
-  unname(hub_names[disease])
+  hub_names[[disease]]
 }
 
 
@@ -83,7 +83,7 @@ get_hub_name <- function(disease) {
 #' @export
 get_hub_repo_name <- function(disease) {
   rlang::arg_match(disease, names(hub_repo_names))
-  unname(hub_repo_names[disease])
+  hub_repo_names[[disease]]
 }
 
 
@@ -95,7 +95,7 @@ get_hub_repo_name <- function(disease) {
 #' @noRd
 get_hub_repo_owner <- function(disease) {
   rlang::arg_match(disease, names(hub_repo_owners))
-  unname(hub_repo_owners[disease])
+  hub_repo_owners[[disease]]
 }
 
 
@@ -127,7 +127,7 @@ get_hub_repo_url <- function(disease) {
 #' @export
 get_disease_name <- function(disease) {
   rlang::arg_match(disease, names(disease_display_names))
-  unname(disease_display_names[disease])
+  disease_display_names[[disease]]
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,7 +42,7 @@ disease_display_names <- c(
 #' @return Character string with the NHSN column name
 #' @export
 get_nhsn_col_name <- function(disease) {
-  rlang::arg_match(disease, names(nhsn_col_names))
+  checkmate::assert_choice(disease, names(nhsn_col_names))
   nhsn_col_names[[disease]]
 }
 
@@ -52,7 +52,7 @@ get_nhsn_col_name <- function(disease) {
 #' @return Character string with the NSSP column name
 #' @export
 get_nssp_col_name <- function(disease) {
-  rlang::arg_match(disease, names(nssp_col_names))
+  checkmate::assert_choice(disease, names(nssp_col_names))
   nssp_col_names[[disease]]
 }
 
@@ -67,7 +67,7 @@ get_nssp_col_name <- function(disease) {
 #' @return Character. Hub name (e.g., "CovidHub", "RSVHub", "FluSight").
 #' @export
 get_hub_name <- function(disease) {
-  rlang::arg_match(disease, names(hub_names))
+  checkmate::assert_choice(disease, names(hub_names))
   hub_names[[disease]]
 }
 
@@ -82,7 +82,7 @@ get_hub_name <- function(disease) {
 #' @return Character. GitHub repository name.
 #' @export
 get_hub_repo_name <- function(disease) {
-  rlang::arg_match(disease, names(hub_repo_names))
+  checkmate::assert_choice(disease, names(hub_repo_names))
   hub_repo_names[[disease]]
 }
 
@@ -94,7 +94,7 @@ get_hub_repo_name <- function(disease) {
 #' @return Character. GitHub organization name.
 #' @noRd
 get_hub_repo_owner <- function(disease) {
-  rlang::arg_match(disease, names(hub_repo_owners))
+  checkmate::assert_choice(disease, names(hub_repo_owners))
   hub_repo_owners[[disease]]
 }
 
@@ -126,7 +126,7 @@ get_hub_repo_url <- function(disease) {
 #' "Influenza").
 #' @export
 get_disease_name <- function(disease) {
-  rlang::arg_match(disease, names(disease_display_names))
+  checkmate::assert_choice(disease, names(disease_display_names))
   disease_display_names[[disease]]
 }
 

--- a/R/write_webtext.R
+++ b/R/write_webtext.R
@@ -352,8 +352,8 @@ generate_webtext_block <- function(
   excluded_locations = NULL,
   input_format = "csv"
 ) {
-  rlang::arg_match(disease, c("covid", "rsv"))
-  rlang::arg_match(input_format, c("csv", "tsv", "parquet"))
+  checkmate::assert_choice(disease, choices = c("covid", "rsv"))
+  checkmate::assert_choice(input_format, choices = c("csv", "tsv", "parquet"))
 
   reference_date <- lubridate::as_date(reference_date)
 

--- a/R/write_webtext.R
+++ b/R/write_webtext.R
@@ -34,7 +34,7 @@ check_hospital_reporting_rate <- function(
   )
 
   disease_abbrs <- c(covid = "c19", rsv = "rsv")
-  disease_abbr <- unname(disease_abbrs[disease])
+  disease_abbr <- disease_abbrs[[disease]]
 
   reporting_column <- glue::glue(
     "totalconf{disease_abbr}newadmperchosprepabove80pct"

--- a/R/write_webtext.R
+++ b/R/write_webtext.R
@@ -33,11 +33,8 @@ check_hospital_reporting_rate <- function(
     )
   )
 
-  disease_abbr <- dplyr::case_match(
-    disease,
-    "covid" ~ "c19",
-    "rsv" ~ "rsv"
-  )
+  disease_abbrs <- c(covid = "c19", rsv = "rsv")
+  disease_abbr <- unname(disease_abbrs[disease])
 
   reporting_column <- glue::glue(
     "totalconf{disease_abbr}newadmperchosprepabove80pct"
@@ -206,13 +203,12 @@ compute_target_webtext_values <- function(
   target_type <- get_target_data_type(target)
 
   format_forecast <- function(x) {
-    if (target_type == "hosp") {
-      round_to_place(x)
-    } else if (target_type == "prop_ed") {
-      janitor::signif_half_up(x * 100, 2)
-    } else {
+    switch(
+      target_type,
+      hosp = round_to_place(x),
+      prop_ed = janitor::signif_half_up(x * 100, 2),
       cli::cli_abort("Unknown target type: {target_type}")
-    }
+    )
   }
 
   target_ensemble <- ensemble_data |>
@@ -357,8 +353,8 @@ generate_webtext_block <- function(
   excluded_locations = NULL,
   input_format = "csv"
 ) {
-  checkmate::assert_choice(disease, choices = c("covid", "rsv"))
-  checkmate::assert_choice(input_format, choices = c("csv", "tsv", "parquet"))
+  rlang::arg_match(disease, c("covid", "rsv"))
+  rlang::arg_match(input_format, c("csv", "tsv", "parquet"))
 
   reference_date <- lubridate::as_date(reference_date)
 

--- a/R/write_webtext.R
+++ b/R/write_webtext.R
@@ -223,8 +223,8 @@ compute_target_webtext_values <- function(
       .data$target == !!target,
       .data$model != glue::glue("{hub_name}-ensemble")
     ) |>
-    dplyr::pull(.data$model) |>
-    unique()
+    dplyr::distinct(.data$model) |>
+    dplyr::pull(.data$model)
 
   # split contributing teams by designated_model status
   contributing_metadata <- all_model_metadata |>
@@ -261,9 +261,8 @@ compute_target_webtext_values <- function(
 
   n_teams <- contributing_metadata |>
     dplyr::filter(.data$designated_model) |>
-    dplyr::pull(.data$team_name) |>
-    unique() |>
-    length()
+    dplyr::distinct(.data$team_name) |>
+    nrow()
   n_forecasts <- length(teams_in_ensemble)
 
   models_included <- paste0("* ", teams_in_ensemble, collapse = "\n")

--- a/tests/testthat/test_update_hub_target_data.R
+++ b/tests/testthat/test_update_hub_target_data.R
@@ -81,7 +81,7 @@ test_that("update_hub_target_data errors for unsupported disease", {
       base_hub_path = tempdir(),
       disease = "measles"
     ),
-    "must be one of"
+    "Must be element of set \\{'covid','rsv'\\}"
   )
 })
 

--- a/tests/testthat/test_update_hub_target_data.R
+++ b/tests/testthat/test_update_hub_target_data.R
@@ -81,7 +81,7 @@ test_that("update_hub_target_data errors for unsupported disease", {
       base_hub_path = tempdir(),
       disease = "measles"
     ),
-    "Must be element of set \\{'covid','rsv'\\}"
+    "must be one of"
   )
 })
 


### PR DESCRIPTION
This PR came about via STF-LC discussions on refactoring, with me giving some Fowler Refactoring categories e.g. "Data Clumping" and "Insider Trading", for `hubhelpr`, which prompted Damon to examine some of the `hubhelpr` and suggest improvements for being more idiomatic.

The following changes are included:

* Named vectors for replacing `checkmate::assert_choice + dplyr::case_when` with `rlang::arg_match` + named vector.
* `checkmate::assert_choice`s replaced with `rlang::arg_match`
* `dplyr::case_whens`s retained in all instances that were not just key lookups 
