### PR TITLE
explicitly convert target data to a tibble 

### DIFF
--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -305,7 +305,8 @@ update_hub_target_data <- function(
   }
 
   if (fs::file_exists(output_file)) {
-    existing_target_data <- forecasttools::read_tabular(output_file)
+    existing_target_data <- forecasttools::read_tabular(output_file) |>
+      dplyr::as_tibble()
   } else {
     existing_target_data <- NULL
   }


### PR DESCRIPTION
Apparently explicitly converting to a tibble closes arrow references