### PR TITLE
Fix Parquet File Lock Error On Windows 

### DIFF
--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -315,6 +315,7 @@ update_hub_target_data <- function(
   if (fs::file_exists(output_file)) {
     existing_target_data <- forecasttools::read_tabular(output_file) |>
       dplyr::as_tibble()
+    gc()
   } else {
     existing_target_data <- NULL
   }


### PR DESCRIPTION
This PR (I believe) should fix the `parquet` locking error due to how memory works with `arrow` on Windows for R CMD check.

Example error (<https://github.com/CDCgov/hubhelpr/actions/runs/24892625763/job/72888730178#step:6:404>) (see line 320): 

> Error: Error: IOError: Failed to open local file 'C:/Users/runneradmin/AppData/Local/Temp/Rtmp0WvvNZ/working_dir/RtmpagVmOO/base_hub_dup_covid_17d05103ce6/target-data/time-series.parquet'. Detail: [Windows error 1224] The requested operation cannot be performed on a file with a user-mapped section open.