### PR TITLE
Move Garbage Collection Call To Tests

### DIFF
--- a/R/update_hub_target_data.R
+++ b/R/update_hub_target_data.R
@@ -315,7 +315,6 @@ update_hub_target_data <- function(
   if (fs::file_exists(output_file)) {
     existing_target_data <- forecasttools::read_tabular(output_file) |>
       dplyr::as_tibble()
-    gc()
   } else {
     existing_target_data <- NULL
   }

--- a/tests/testthat/test_update_hub_target_data.R
+++ b/tests/testthat/test_update_hub_target_data.R
@@ -112,6 +112,7 @@ purrr::walk(c("covid", "rsv"), function(disease) {
           as_of = lubridate::as_date("2025-08-18"),
           excluded_locations = test_excluded_locations
         )
+        gc()
 
         # second run with same data errors by default
         expect_error(
@@ -123,6 +124,7 @@ purrr::walk(c("covid", "rsv"), function(disease) {
           ),
           "overwrite"
         )
+        gc()
 
         # second run with overwrite_existing = TRUE
         # (should succeed)


### PR DESCRIPTION
From @sbidari :

> Why not `gc()` in test that calls this function repeatedly (for memory handoff) instead of adding it to the function itself?