### PR TITLE
Update Version Usage With Hubhelpr And Dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+          extra-repositories: https://hubverse-org.r-universe.dev
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: https://hubverse-org.r-universe.dev
 
       - uses: r-lib/actions/setup-pandoc@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: https://hubverse-org.r-universe.dev
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     fs,
     glue,
     hardhat,
-    hubData,
+    hubData (>= 2.2.0),
     hubEnsembles,
     jsonlite,
     lubridate,
@@ -45,13 +45,9 @@ Imports:
     tibble
 Remotes:
     forecasttools=github::cdcgov/forecasttools,
-    hubAdmin=github::hubverse-org/hubAdmin,
-    hubUtils=github::hubverse-org/hubUtils,
-    hubData=github::hubverse-org/hubData@1d3f7eb4180e367041e8fee6480dab8f79b031bc,
-    hubEnsembles=github::hubverse-org/hubEnsembles,
-    hubValidations=github::hubverse-org/hubValidations,
     epipredict=github::cmu-delphi/epipredict,
     epiprocess=github::cmu-delphi/epiprocess
+Additional_repositories: https://hubverse-org.r-universe.dev
 Suggests:
     httptest2,
     testthat (>= 3.0.0),


### PR DESCRIPTION
This PR makes the following changes:

* `hubData` &rarr; `hubData` (>= 2.2.0)
* Removes 5 hubverse dev-source entries.
* Adds `Additional_repositories: https://hubverse-org.r-universe.dev` so R CMD INSTALL / `pak` resolve hubverse dependencis from r-universe.
* ...?