### PR TITLE
Add s3 bucket upload action

### DIFF
--- a/actions/s3-bucket-upload/action.yaml
+++ b/actions/s3-bucket-upload/action.yaml
@@ -1,0 +1,103 @@
+name: "Upload hub contents to an AWS bucket"
+description: "Upload contents of a Hub GitHub repository to a Hubverse-format Amazon Web Services (AWS) Simple Storage Service (S3) bucket."
+
+inputs:
+  aws_account:
+    description: "AWS account ID."
+    required: true
+  base_hub_path:
+    description: "Path to the hub repository root directory."
+    required: false
+    default: "."
+  directories:
+    description: "Hub directories to sync with the upstream bucket as a multi-line string, one directory per line. Defaults yield a fairly comprehensive snapshot compatible with `hubData` functions."
+    required: false
+    default: |
+      auxiliary-data
+      hub-config
+      model-abstracts
+      model-metadata
+      target-data
+      model-output
+  dry_run:
+    description: Run rclone sync in dry-run mode? Useful for testing without overwriting. Boolean, default `false`.
+    required: false
+    default: "false"
+  enforce_default_branch:
+    description: "Require that the action be run from the default branch? This guards against accidental overwrites of the S3 bucket with non-canonical Hub data by workflows running from non-default branches. Boolean, default `true`"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+        # this may be redundant with checks on the bucket end.
+      - name: "Optionally enforce default branch"
+        if: ${{ fromJSON(inputs.enforce_default_branch) }}
+        # composite actions only allow string inputs
+        # https://github.com/actions/runner/issues/2238
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/${{ github.event.repository.default_branch }}" ]; then
+            echo "Error: tried to run action from non-default branch with 'enforce_default_branch' set to 'true'." >&2
+            exit 1
+          fi
+        shell: bash
+
+      - name: "Get Hub cloud config"
+        # save cloud-related fields from admin config as environment variables
+        # (jq json parser is installed on Github-hosted runners)
+        run: |
+          cloud_enabled=$(jq -r '.cloud.enabled' ${{ inputs.base_hub_path }}/hub-config/admin.json) \
+            && echo "CLOUD_ENABLED=$cloud_enabled"
+          cloud_storage_location=$(jq -r '.cloud.host.storage_location' ${{ inputs.base_hub_path }}/hub-config/admin.json) \
+            && echo "CLOUD_STORAGE_LOCATION=$cloud_storage_location"
+          echo "CLOUD_ENABLED=$cloud_enabled" >> $GITHUB_ENV
+          echo "CLOUD_STORAGE_LOCATION=$cloud_storage_location" >> $GITHUB_ENV
+        shell: bash
+
+      - name: "Configure AWS credentials"
+        # request credentials to assume the Hub's AWS role via OpenID Connect
+        if: ${{ fromJSON(env.CLOUD_ENABLED) }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ inputs.aws_account }}:role/${{ env.CLOUD_STORAGE_LOCATION }}
+          aws-region: us-east-1
+
+      - name: "Install latest rclone"
+        if: ${{ fromJSON(env.CLOUD_ENABLED) }}
+        # Install the latest rclone from the official script rather than the apt
+        # package: the Debian/Ubuntu version is too old to parse the inline
+        # connection-string remotes (":s3,provider=AWS,env_auth:...") used in the
+        # sync step below, and instead fails with "config name contains invalid
+        # characters".
+        # https://github.com/rclone/rclone/issues/6060
+        run: |
+          curl -fsSL https://rclone.org/install.sh | sudo bash
+          rclone version
+        shell: bash
+
+      - name: "Sync files to bucket"
+        if: ${{ fromJSON(env.CLOUD_ENABLED) }}
+        run: |
+          readarray -t DIRECTORIES <<<  "${{ inputs.directories }}"
+          for DIRECTORY in "${DIRECTORIES[@]}"
+          do
+            if [[ !($DIRECTORY = *[![:space:]]*) ]]; then continue; fi; # skip any all-whitespace entries
+            dir_cloud_prefix="${{ env.CLOUD_STORAGE_LOCATION }}"
+
+            if [ "$DIRECTORY" = "model-output" ]
+            then
+              dir_cloud_prefix=$dir_cloud_prefix/raw
+            fi
+
+            if [ -d "${{ inputs.base_hub_path }}/$DIRECTORY" ]
+            then
+              echo "Syncing local $DIRECTORY to remote $dir_cloud_prefix/$DIRECTORY"
+              rclone sync \
+                "${{ inputs.base_hub_path }}/$DIRECTORY/" \
+                ":s3,provider=AWS,env_auth:$dir_cloud_prefix/$DIRECTORY" \
+                --checksum --verbose --stats-one-line --config=/dev/null \
+                ${{ fromJSON(inputs.dry_run) && '--dry-run' || ''}} # conditionally add --dry-run flag
+            fi
+          done
+        shell: bash

--- a/actions/s3-bucket-upload/action.yaml
+++ b/actions/s3-bucket-upload/action.yaml
@@ -85,6 +85,8 @@ runs:
             if [[ !($DIRECTORY = *[![:space:]]*) ]]; then continue; fi; # skip any all-whitespace entries
             dir_cloud_prefix="${{ env.CLOUD_STORAGE_LOCATION }}"
 
+           # unlike other data, model-outputs are synced to a "raw" location
+           # so we can transform it before presenting to users
             if [ "$DIRECTORY" = "model-output" ]
             then
               dir_cloud_prefix=$dir_cloud_prefix/raw


### PR DESCRIPTION
Creates a composite action that wraps the upload steps in https://github.com/hubverse-org/hubverse-actions/blob/main/hubverse-aws-upload/hubverse-aws-upload.yaml

This is what RSVHub's upload workflow looks like using the action: https://github.com/CDCgov/rsv-forecast-hub/blob/e734c88f4cd59a9c76e32a97e3fcb470841350e7/.github/workflows/hubverse-aws-upload.yaml

The composite action allows for:

- dry runs
- configurable synced directories

I have tested equivalence of the rsync commands that would get run by running a modified version of the action that just prints the commands rather than running them: https://github.com/CDCgov/rsv-forecast-hub/actions/runs/29615668189/job/88415326466

All looks as expected to me. To test this more rigorously and realistically, I think we'd want a sandbox hub and corresponding sandbox AWS bucket. @annakrystalli I am assuming no such thing exists, but please let me know if it does. I'm comfortable merging without such a test but lmk if you disagree @sbidari / @O957 