### PR TITLE
Update CODEOWNERS File Following STF Team Detail

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dylanhmorris @O957 @sbidari
+* @dylanhmorris @O957


### PR DESCRIPTION
This PR removes `sbidari` from `CODEOWNERS` given that she is working under NNH at the moment.